### PR TITLE
Support script mode shebang (ts-node-script)

### DIFF
--- a/shebang-trim.js
+++ b/shebang-trim.js
@@ -5,6 +5,7 @@ const readline = require('readline')
 const writeFileAtomically = require('write-file-atomically')
 
 const oldShebang = '#!/usr/bin/env ts-node'
+const oldShebangScriptMode = '#!/usr/bin/env ts-node-script'
 const newShebang = '#!/usr/bin/env node'
 
 function transformShebangLine(line) {
@@ -12,7 +13,11 @@ function transformShebangLine(line) {
     throw Error('Not a shebang')
   }
 
-  if (line === oldShebang || line === newShebang) {
+  if (
+    line === oldShebang ||
+    line === oldShebangScriptMode ||
+    line === newShebang
+  ) {
     return newShebang
   } else {
     throw Error(`Cowardly refusing to convert unknown shebang: ${line}`)

--- a/shebang-trim.spec.js
+++ b/shebang-trim.spec.js
@@ -34,6 +34,20 @@ describe('shebang-trim', () => {
       expect(newContents).to.equal(source.replace('ts-node', 'node'))
     })
 
+    it('when a file contains the old shebang (script mode), it rewrites it', async () => {
+      const source = `#!/usr/bin/env ts-node-script
+      function main() {
+        console.log('Hello, world!')
+      }
+      `
+      await writeSource(source)
+
+      await rewriteShebang(path)
+
+      const newContents = await fs.readFile(path, 'utf8')
+      expect(newContents).to.equal(source.replace('ts-node-script', 'node'))
+    })
+
     it('when a file contains the new shebang, it does nothing', async () => {
       const source = `#!/usr/bin/env node
       function main() {


### PR DESCRIPTION
According to the documentation of ts-node, `ts-node-script` is preferred over `ts-node` now. Let's support it.